### PR TITLE
fix(APT): fix fun-install apt get install with multi pkg

### DIFF
--- a/lib/commands/apt-get.js
+++ b/lib/commands/apt-get.js
@@ -3,11 +3,10 @@
 const { installPackage } = require('../install/install');
 
 async function install(packages, options) {
-  await installPackage('apt', packages.join(' '), {
+  await installPackage('apt', packages, {
     cwd: process.cwd(),
     target: options.target
   });
-  
 }
 
 module.exports = install;

--- a/lib/install/task.js
+++ b/lib/install/task.js
@@ -124,8 +124,8 @@ class AptTask extends InstallTask {
   
   async dlPkg(pkgName) {
     log.info(green('     => ') + cyan('apt-get install -y -d -o=dir::cache=%s %s --reinstall'), this.cacheDir, pkgName);
-
-    await this._exec(['sudo', 'apt-get', 'install', '-y', '-d', `-o=dir::cache=${this.cacheDir}`, pkgName, '--reinstall']);
+    pkgName = Array.isArray(pkgName) ? pkgName : [pkgName];
+    await this._exec(['sudo', 'apt-get', 'install', '-y', '-d', `-o=dir::cache=${this.cacheDir}`, ...pkgName, '--reinstall']);
   }
 
   async instDeb() {


### PR DESCRIPTION
修复在 fun-install apt-get install 多个 pkg 时报 E: Unable to locate package xxx yyy 的 Issue
```
Task => AptTask
     => sudo apt-get update (if need)
     => apt-get install -y -d -o=dir::cache=/code/.fun/tmp/install zip unzip --reinstall
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package zip unzip
```