### PR TITLE
ellison/fix 'fun build' for maven under windows

### DIFF
--- a/lib/taskflows/java/maven/maven-compile-task.js
+++ b/lib/taskflows/java/maven/maven-compile-task.js
@@ -17,7 +17,7 @@ class MavenCompileTask extends Task {
   }
 
   async run() {
-    
+
     if (!await fs.pathExists(this.manifestFile)) {
       log.info('manifestFile is ' + this.manifestFile);
       log.info(`manifestFile dont exist, no need to run ${this.name} task`);
@@ -26,7 +26,7 @@ class MavenCompileTask extends Task {
 
     const command = 'mvn';
     const commandArgs = ['clean', 'compile'];
-    
+
     await cmd.execCommand(command, commandArgs, path.resolve(this.artifactDir));
   }
 }

--- a/lib/taskflows/python/pip/pip-task-flow.js
+++ b/lib/taskflows/python/pip/pip-task-flow.js
@@ -17,11 +17,11 @@ class PipTaskFlow extends TaskFlow {
 
     // make sure artifactDir exist
     await fs.mkdirp(this.artifactDir);
-        
+
     this.installTasks.push(new PipInstallTask(this.sourceDir, this.artifactDir));
     this.installTasks.push(new CopySourceTask(this.sourceDir, this.artifactDir, this.excludeFiles));
   }
-  
+
   static getManifestName() {
     return 'requirements.txt';
   }

--- a/lib/taskflows/task.js
+++ b/lib/taskflows/task.js
@@ -10,16 +10,11 @@ class Task {
 
   async beforeRun() {
     log.info('running task: ' + this.name);
-    
   }
 
-  async run() {
+  async run() {}
 
-  }
-
-  async afterRun() {
-
-  }
+  async afterRun() {}
 
   async start() {
     await this.beforeRun();

--- a/lib/taskflows/taskflow.js
+++ b/lib/taskflows/taskflow.js
@@ -10,17 +10,16 @@ const manifestItemParser = {
   'package.json': {
     parse: (manifestFilePath, cwd) => {
       const solutions = [];
-      
       try {
         const dependencyManagerName = 'npm';
 
         const packageJson = require(manifestFilePath);
-  
+
         const dependencies = packageJson.dependencies;
         if (dependencies) {
           for (const name of Object.keys(dependencies)) {
             solutions.push(packageSolutionFactory(dependencyManagerName, name, {
-              cwd: cwd 
+              cwd: cwd
             }));
           }
         }
@@ -60,7 +59,7 @@ class TaskFlow {
   }
 
   async beforeRun() {
-    log.info('running task flow %s', this.name);  
+    log.info('running task: flow %s', this.name);
 
     const manifestFileName = this.constructor.getManifestName();
     if (!manifestFileName) {

--- a/lib/utils/command.js
+++ b/lib/utils/command.js
@@ -1,9 +1,9 @@
 'use strict';
-
-const child_process = require('child_process');
 const log = require('../utils/log');
-const { addEnv } = require('../install/env');
+const iconv = require('iconv-lite');
+const child_process = require('child_process');
 const { Transform } = require('stream');
+
 const _ = require('lodash');
 
 class ChunkSplitTransform extends Transform {
@@ -33,12 +33,12 @@ class ChunkSplitTransform extends Transform {
 }
 
 async function execCommand(command, commandArgs, cwd, env) {
+  // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
   return new Promise((resolve, reject) => {
-    const resolvedEnv = addEnv(env);
-
     const child = child_process.spawn(command, commandArgs, {
       cwd,
-      env: resolvedEnv
+      env: Object.assign({}, process.env, env),
+      shell: process.platform === 'win32'
     });
 
     const errorMsgs = [];
@@ -79,8 +79,8 @@ async function execCommand(command, commandArgs, cwd, env) {
       }
     });
 
-    child.stdout.pipe(stdoutChunker);
-    child.stderr.pipe(stderrChunker);
+    child.stdout.pipe(iconv.decodeStream('cp936')).pipe(stdoutChunker);
+    child.stderr.pipe(iconv.decodeStream('cp936')).pipe(stderrChunker);
   });
 }
 

--- a/lib/utils/command.js
+++ b/lib/utils/command.js
@@ -3,7 +3,6 @@ const log = require('../utils/log');
 const iconv = require('iconv-lite');
 const child_process = require('child_process');
 const { Transform } = require('stream');
-
 const _ = require('lodash');
 
 class ChunkSplitTransform extends Transform {
@@ -32,13 +31,15 @@ class ChunkSplitTransform extends Transform {
   }
 }
 
+const isWin = process.platform === 'win32';
+
 async function execCommand(command, commandArgs, cwd, env) {
   // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
   return new Promise((resolve, reject) => {
     const child = child_process.spawn(command, commandArgs, {
       cwd,
       env: Object.assign({}, process.env, env),
-      shell: process.platform === 'win32'
+      shell: isWin
     });
 
     const errorMsgs = [];
@@ -79,8 +80,13 @@ async function execCommand(command, commandArgs, cwd, env) {
       }
     });
 
-    child.stdout.pipe(iconv.decodeStream('cp936')).pipe(stdoutChunker);
-    child.stderr.pipe(iconv.decodeStream('cp936')).pipe(stderrChunker);
+    if (isWin) {
+      child.stdout.pipe(iconv.decodeStream('cp936')).pipe(stdoutChunker);
+      child.stderr.pipe(iconv.decodeStream('cp936')).pipe(stderrChunker);
+    } else {
+      child.stdout.pipe(stdoutChunker);
+      child.stderr.pipe(stderrChunker);
+    }
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,6 +1060,17 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "extglob": {
@@ -1529,10 +1540,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.1.tgz",
+      "integrity": "sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2846,8 +2856,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "git-ignore-parser": "0.0.2",
     "glob": "^7.1.6",
     "httpx": "^2.2.2",
+    "iconv-lite": "^0.5.1",
     "ignore": "^5.1.4",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.14",


### PR DESCRIPTION
fixes #https://github.com/alibaba/funcraft/issues/878
fixes #https://github.com/alibaba/funcraft/issues/881

1. 修复：Node.js child_process 模块中 spawn 方法中执行外部命令（ mvn clean compile 命令等）报错问题。
原因：spawn 的 options 还允许为子进程设置环境变量，默认是 process.env，但实际将 Path 覆盖掉了，导致外部命令找不到。

2. 修复：中文 windows 的命令行一般默认使用cp936编码（就是gbk），导致输出中文乱码问题。
workaround：因为node本身不支持 gbk，借助 iconv-lite 库流式处理转码。