### PR TITLE
feat(.fun): configurable save path

### DIFF
--- a/lib/install/env.js
+++ b/lib/install/env.js
@@ -1,8 +1,12 @@
 'use strict';
 
+const { getToolCachePath } = require('../utils/utils');
+
 function addEnv(envVars) {
+  const toolCachePath = getToolCachePath();
+
   const envs = Object.assign({}, process.env, envVars);
-  const prefix = '/code/.fun/root';
+  const prefix = `/code/${toolCachePath}/root`;
 
   const libPath = [`${prefix}/usr/lib`, `${prefix}/usr/lib/x86_64-linux-gnu`].join(':');
   const defaultLibPath = `${libPath}:/code:/code/lib:/usr/local/lib`;
@@ -14,7 +18,7 @@ function addEnv(envVars) {
 
   const paths = ['/usr/local/bin', '/usr/local/sbin', '/usr/bin', '/usr/sbin', '/sbin', '/bin'];
   const defaultPath = paths.join(':');
-  const customPath = paths.map(p => `${prefix}${p}`).join(':') + ':/code/.fun/python/bin';
+  const customPath = paths.map(p => `${prefix}${p}`).join(':') + `:/code/${toolCachePath}/python/bin`;
   if (envs['PATH']) {
     envs['PATH'] = `${envs['PATH']}:${customPath}:${defaultPath}`;
   } else {
@@ -22,7 +26,7 @@ function addEnv(envVars) {
   }
 
   if (!envs['PYTHONUSERBASE']) {
-    envs['PYTHONUSERBASE'] = '/code/.fun/python';
+    envs['PYTHONUSERBASE'] = `/code/${toolCachePath}/python`;
   }
 
   return envs;

--- a/lib/install/task.js
+++ b/lib/install/task.js
@@ -5,6 +5,7 @@ const fs = require('fs-extra');
 const log = require('../utils/log');
 const path = require('path');
 const { cyan, green } = require('colors');
+const { getToolCachePath } = require('../utils/utils');
 
 class Task {
   constructor(name, { cwd, env = {}, target, additionalArgs = [] } = {}) {
@@ -63,7 +64,7 @@ class PipTask extends InstallTask {
 
     const cmd = ['pip', 'install', '--user', '--upgrade', this.pkgName, ...this.additionalArgs];
 
-    const pythonUserBase = path.join(this.target || path.join(this.cwd, '.fun'), 'python');
+    const pythonUserBase = path.join(this.target || path.join(this.cwd, getToolCachePath()), 'python');
 
     log.info(green('     => ') + cyan(`PYTHONUSERBASE=${pythonUserBase} ${cmd.join(' ')}`));
 
@@ -95,9 +96,11 @@ class NpmTask extends InstallTask {
 class AptTask extends InstallTask {
 
   constructor(pkgName, context) {
+    const toolCachePath = getToolCachePath();
+
     super('AptTask', pkgName, context);
-    this.cacheDir = path.join(this.cwd, '.fun', 'tmp', 'install');
-    this.instDir = path.join(this.target || path.join(this.cwd, '.fun', 'root'));
+    this.cacheDir = path.join(this.cwd, toolCachePath, 'tmp', 'install');
+    this.instDir = path.join(this.target || path.join(this.cwd, toolCachePath, 'root'));
   }
 
   async beforeRun() {

--- a/lib/taskflows/python/pip/pip-install-task.js
+++ b/lib/taskflows/python/pip/pip-install-task.js
@@ -6,6 +6,7 @@ const Task = require('../../task');
 const path = require('path');
 const cmd = require('../../../utils/command');
 const log = require('../../../utils/log');
+const { getToolCachePath } = require('../../../utils/utils')
 
 const manifestFileName = 'requirements.txt';
 
@@ -15,7 +16,7 @@ class PipInstallTask extends Task {
     this.sourceDir = sourceDir;
     this.manifestFile = path.join(this.sourceDir, manifestFileName);
     this.artifactDir = artifactDir;
-    this.pythonUserBase = path.join(this.artifactDir, '.fun', 'python');
+    this.pythonUserBase = path.join(this.artifactDir, getToolCachePath(), 'python');
   }
 
   async run() {

--- a/lib/utils/ignore.js
+++ b/lib/utils/ignore.js
@@ -1,13 +1,14 @@
 'use strict';
 
+const { getToolCachePath } = require('../utils/utils');
 const parser = require('git-ignore-parser'),
   ignore = require('ignore'),
   fs = require('fs-extra'),
   path = require('path');
 
-const ignoredFile = ['.git', '.svn', '.env', '.fun/nas', '.fun/tmp', '.DS_Store', '.fun/build'];
-
 module.exports = function (baseDir) {
+  const toolCachePath = getToolCachePath();
+  const ignoredFile = ['.git', '.svn', '.env', `${toolCachePath}/nas`, `${toolCachePath}/tmp`, '.DS_Store', `${toolCachePath}/build`];
 
   const ignoreFilePath = `${baseDir}/.funignore`;
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function getToolCachePath() {
+  return process.env.TOOL_CACHE_PATH || '.fun';
+}
+
+module.exports = {
+  getToolCachePath,
+}


### PR DESCRIPTION
需求：现在其他的工具依赖此包缓存目录必须写成 .fun, 无法修改成其他的路径，现在想通过其他的方式修改缓存目录

解决方案：通过临时环境变量的方式【改动量小】。
taskflow 文件中出现的 .fun，主要是 build 之后 copy 所需要排除的文件，通过环境变量 BUILD_EXCLIUDE_FILES 传入配置, 传入值示例 .s/build;.s/nas
其他的路径 .fun， 可通过配置环境变量 TOOL_CACHE_PATH 传入配置, 传入值示例 .s